### PR TITLE
Fix md5sum check in read.neuronlistfh

### DIFF
--- a/R/neuronlistfh.R
+++ b/R/neuronlistfh.R
@@ -225,7 +225,7 @@ read.neuronlistfh <- function(file, localdir=NULL) {
     if(!file.exists(localdir)) dir.create(localdir, recursive=TRUE)
     saveRDS(obj,file=tmpFile)
     # and copy / replace existing copy
-    if(!file.exists(cached.neuronlistfh) || md5sum(cached.neuronlistfh)!=md5sum(tmpFile)){
+    if(!file.exists(cached.neuronlistfh) || !all.equal(md5sum(cached.neuronlistfh), md5sum(tmpFile))) {
       message("Updating cached neuronlistfh: ",basename(cached.neuronlistfh))
       file.copy(tmpFile,cached.neuronlistfh)
     }


### PR DESCRIPTION
md5sum returns a vector and so previously there was a complaint when the if statement wasn't short-circuited.
