### PR TITLE
Wrap connection clean-up in finally block

### DIFF
--- a/R/neuronlistfh.R
+++ b/R/neuronlistfh.R
@@ -241,13 +241,13 @@ as.neuronlist.neuronlistfh<-function(l, ...){
       "Unable to download file."
       stop(e)
     })
+  }, finally = {
+    # Deal with connection leak
+    connAfter <- rownames(showConnections(all=T))
+    connNew <- setdiff(connAfter,connBefore)
+    if(length(connNew) > 0)
+      close(getConnection(as.integer(connNew)))
   })
-  
-  # Deal with connection leak
-  connAfter <- rownames(showConnections(all=T))
-  connNew <- setdiff(connAfter,connBefore)
-  if(length(connNew) > 0)
-    close(getConnection(as.integer(connNew)))
 }
 
 #' @S3method as.list neuronlistfh


### PR DESCRIPTION
I don't really understand how this could have worked before, outside of the finally block, when it now requires placing inside it...
