### PR TITLE
Switch to using neurodebian-travis.sh script for NeuroDebian setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ before_install:
   - ./travis-tool.sh bootstrap
   - ./travis-tool.sh r_binary_install rgl RANN igraph filehash digest testthat
   - bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
-  - sudo apt-get update
   - sudo apt-get install cmtk --no-install-recommends
 install:
   - ./travis-tool.sh install_deps


### PR DESCRIPTION
In the future, the script may be modified to point to a more Travis-appropriate mirror.
