### PR TITLE
Trigger rebuild of flycircuit after successful Travis CI build

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.travis\.yml$
+travisbuildflycircuit.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,11 @@ notifications:
     on_success: change
     on_failure: change
 env:
-  - global:
+  global:
+    - secure: pGh2sZTLYXbvjnOHFN5rcT+H/hNAlg7o325Pa1RQdjmtK0CWjTh0j/tomIeI9LkFOEgaglUIKQmjAOZWXWyhI4ig2x5L6sYEDY491LYHridGsbBcFL/ND3H/zaBZ0qoh3Yofj37Y2fM6lp7W10Y4WueFxUmwncbJRT/Xrai/n/c=
     - WARNINGS_ARE_ERRORS=1
     - _R_CHECK_FORCE_SUGGESTS_=0
     - DISPLAY=:99.0
+after_success:
+  - chmod 755 ./travisbuildflycircuit.sh
+  - ./travisbuildflycircuit.sh

--- a/travisbuildflycircuit.sh
+++ b/travisbuildflycircuit.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Get last flycircuit build number
+BUILD_NUM=$(curl -s 'https://api.travis-ci.org/repos/ajdm/flycircuit/builds' | grep -o '^\[{"id":[0-9]*,' | grep -o '[0-9]' | tr -d '\n')
+
+# Restart last flycircuit build
+curl -X POST https://api.travis-ci.org/builds/$BUILD_NUM/restart --header "Authorization: token "$AUTH_TOKEN


### PR DESCRIPTION
While [Travis CI](http://travis-ci.org) is useful for checking that commits do not break nat, it currently does not check to see whether commits to nat break [flycircuit](https://github.com/jefferis/flycircuit), as [dependent builds](https://github.com/travis-ci/travis-ci/issues/249) have not yet been implemented. As such, flycircuit-breaking commits will only be flagged by Travis when either a flycircuit build is manually restarted or a new change is pushed to the flycircuit repo.

To counter this, these changes trigger a rebuild of flycircuit after a successful nat build via the `travisbuildflycircuit.sh` script. If merged, line 4 of the script should be changed so that `ajdm/flycircuit` becomes `jefferis/flycircuit` and the secure value, containing the [Access Token](http://blog.travis-ci.com/2013-01-28-token-token-token/), in the `.travis.yaml` file (line 19) should also be updated. In particular, the correct value can be generated with the Travis CLI tool, using:

```
travis encrypt -r jefferis/nat 'AUTH_TOKEN="<insert_access_token_here>"'
```

with the access token being obtained with:

```
travis login && travis token
```

_Side-node: I actually obtained a token by looking at the HTTP request sent when the 'restart build' button for my flycircuit repo was clicked as I had difficulty in installing the CLI tool. Now that I have it up and running, I note that the tool gives me a different token, although the one I used is accepted._
