### PR TITLE
Teach read.amiramesh to handle gzipped files (via R.utils) and reinstate test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,8 @@ Imports:
     methods,
     filehash,
     digest,
-    nat.utils
+    nat.utils,
+    R.utils
 Suggests:
     testthat
 License: GPL-3

--- a/R/amiramesh-io.R
+++ b/R/amiramesh-io.R
@@ -32,6 +32,8 @@ read.amiramesh<-function(file,sections=NULL,header=FALSE,simplify=TRUE,
     else endian='big'
   }
   
+  # Check if file is gzipped
+  if(R.utils::isGzipped(file)) file <- R.utils::gunzip(file, temporary=TRUE, overwrite=TRUE, remove=FALSE)
   con=if(binaryfile) file(file,open='rb') else file(file,open='rt')
   on.exit(try(close(con),silent=TRUE))
   h=read.amiramesh.header(con,Verbose=Verbose)

--- a/tests/testthat/test-neuron-io.R
+++ b/tests/testthat/test-neuron-io.R
@@ -706,8 +706,7 @@ test_that("reading identical neuron in 2 amira formats and 3 encodings works",{
                fieldsToExclude='NeuronName')
   expect_equal(l,read.neuron("testdata/neuron/testneuron_am3d_ascii.am.gz"),
                fieldsToExclude='NeuronName')
-  # FIXME see https://github.com/jefferis/nat/issues/14
-  expect_error(suppressWarnings(read.neuron("testdata/neuron/testneuron_am3d.am.gz")))
+  expect_equal(l,read.neuron("testdata/neuron/testneuron_am3d.am.gz"),fieldsToExclude='NeuronName')
 })
 
 test_that("we can identify amira hxlineset neurons",{


### PR DESCRIPTION
One possible implementation of #14. This add R.utils as an import, which is less than ideal, but it does avoid warnings.
