### PR TITLE
Fix mirror so that vectors for dotprops are recalculated

### DIFF
--- a/R/xform.R
+++ b/R/xform.R
@@ -228,10 +228,12 @@ mirror.default<-function(x, mirrorAxisSize, mirrorAxis=c("X","Y","Z"),
   
   # then 
   if(is.null(warpfile) || transform=='flip') {
-    x
+    x.new <- xform(x, reg=diag(4), transformtype=transform, ...)
   } else {
-    xform(x, reg=warpfile, transformtype=transform, ...)
+    x.new <- xform(x, reg=warpfile, transformtype=transform, ...)
   }
+  mostattributes(x.new) <- attributes(x)
+  x.new
 }
 #' @method mirror neuronlist
 #' @S3method mirror neuronlist


### PR DESCRIPTION
Fixes #79. This leaves the manipulation in the first part of the function body and calls `xform()` with an identity matrix as the registration. Attribute juggling is required as we no longer just pass back the original object with the coordinates altered.
