### PR TITLE
Fix cmtk.bindir() to check default CMTK installation dir for Mac OS X

### DIFF
--- a/R/cmtk.R
+++ b/R/cmtk.R
@@ -116,6 +116,7 @@ cmtk.mat2dof<-function(m, f=NULL, centre=NULL, Transpose=TRUE, version=FALSE){
 cmtk.bindir<-function(firstdir=getOption('nat.cmtk.bindir'),
                       extradirs=c('~/bin','/usr/local/lib/cmtk/bin',
                                   '/usr/local/bin','/opt/local/bin',
+                                  '/opt/local/lib/cmtk/bin/',
                                   '/Applications/IGSRegistrationTools/bin'),
                       set=FALSE, check=FALSE, cmtktool='gregxform'){
   bindir=NULL

--- a/man/cmtk.bindir.Rd
+++ b/man/cmtk.bindir.Rd
@@ -5,8 +5,8 @@
 \usage{
 cmtk.bindir(firstdir = getOption("nat.cmtk.bindir"), extradirs = c("~/bin",
   "/usr/local/lib/cmtk/bin", "/usr/local/bin", "/opt/local/bin",
-  "/Applications/IGSRegistrationTools/bin"), set = FALSE, check = FALSE,
-  cmtktool = "gregxform")
+  "/opt/local/lib/cmtk/bin/", "/Applications/IGSRegistrationTools/bin"),
+  set = FALSE, check = FALSE, cmtktool = "gregxform")
 }
 \arguments{
   \item{firstdir}{Character vector specifying path


### PR DESCRIPTION
Fixes #103.
