### PR TITLE
Fix materials.default() to actually return selected attribute from function

### DIFF
--- a/R/im3d.R
+++ b/R/im3d.R
@@ -975,7 +975,7 @@ materials<-function(x, ...) UseMethod("materials")
 #' @rdname materials
 #' @method materials default
 materials.default<-function(x, ...) {
-  m=attr(x,'materials')
+  attr(x,'materials')
 }
 
 #' @description \code{materials.character} will read the materials from an im3d


### PR DESCRIPTION
All the other methods return the value, so I presume this one should too.
