### PR TITLE
Teach write.cmtkreg() to give a warning if versions of CMTK reg differ

### DIFF
--- a/R/cmtk_io.R
+++ b/R/cmtk_io.R
@@ -177,6 +177,7 @@ read.cmtk<-function(con, CheckLabel=TRUE){
 #' @export
 #' @family cmtk-io
 write.cmtkreg<-function(reglist, foldername, version="2.4"){
+  if(!is.null(attr(reglist, 'version')) && (attr(reglist, 'version') != version)) warning("Specified version (", version, ") is not the same as the version stored in the reglist object (", attr(reglist, 'version'), ").")
   dir.create(foldername, showWarnings=FALSE, recursive=TRUE)
   if(!is.list(reglist)) reglist=cmtkreglist(reglist)
   write.cmtk(reglist,file.path(foldername, "registration"),

--- a/tests/testthat/test-cmtk_io.R
+++ b/tests/testthat/test-cmtk_io.R
@@ -19,7 +19,7 @@ test_that("read.cmtk and write.cmtk can round-trip a registration file", {
   reglist=read.cmtkreg(reg)
   tf=tempfile('dofv1.1wshears_copy',fileext='.list')
   on.exit(unlink(tf,recursive=TRUE))
-  write.cmtkreg(reglist,foldername=tf)
+  write.cmtkreg(reglist,foldername=tf,version=1.1)
   ctf=cmtkreg(tf,returnDir=TRUE)
   # equivalent because we are not interested in the file.info attributes
   # though this also removes version attribute which might be worth a thought


### PR DESCRIPTION
This should help us avoid errors when dealing with registrations created when CMTK's handling of affine matrices was broken.
