### PR TITLE
Fix/xyz.character nas

### DIFF
--- a/R/xform.R
+++ b/R/xform.R
@@ -295,8 +295,13 @@ xyzmatrix.default<-function(x, y=NULL, z=NULL, ...) {
 xyzmatrix.character<-function(x, ...) {
   cc=gsub("[^0-9.\\+eE-]+"," ", x)
   cc=trimws(cc)
-  mat=read.table(text = cc)
-  xyzmatrix(mat)
+  # lines with no input (or bad input should be treated as NA)
+  cc[!nzchar(cc)]="NA NA NA"
+  mat=read.table(text = cc, fill = TRUE)
+  res=xyzmatrix(mat)
+  # check we got as many rows as inputs
+  stopifnot(isTRUE(nrow(res)==length(x)))
+  res
 }
 
 

--- a/R/xform.R
+++ b/R/xform.R
@@ -258,6 +258,8 @@ xyzmatrix<-function(x, ...) UseMethod("xyzmatrix")
 #'   columns are character vectors, they will be correctly converted to numeric
 #'   (with a warning for any NA values).
 #'
+#' @section Getting and setting from character vectors:
+#'
 #'   \code{xyzmatrix} can also both get and set 3D coordinates from a character
 #'   vector (including a single data frame column) in which each string encodes
 #'   all 3 coordinates e.g. \code{"-1, 4, 10"}. It should handle a range of
@@ -266,6 +268,24 @@ xyzmatrix<-function(x, ...) UseMethod("xyzmatrix")
 #'   \code{\link{zapsmall}} in the replacement version to try to avoid cases
 #'   where rounding errors result in long strings of digits to the right of the
 #'   decimal place.
+#'
+#'   Replacement into character vectors introduces a number of corner cases when
+#'   there are not exactly 3 numbers to replace in the target vector. We handle
+#'   them as follows: \itemize{
+#'
+#'   \item 0 values in target, >0 in replacement: use a default pattern
+#'
+#'   \item 1-2 values in target, same number of "good" values in replacement:
+#'   insert those replacement value
+#'
+#'   \item 1-2 values in target, different number of values in replacement: use
+#'   default pattern, give a \code{warning}
+#'
+#'   }
+#'
+#'   The default pattern will be the first entry in \code{x} with 3 numbers.
+#'   Should there not be such a value, then the pattern will be \code{"x, y,
+#'   z"}.
 #' @rdname xyzmatrix
 #' @export
 xyzmatrix.default<-function(x, y=NULL, z=NULL, ...) {
@@ -395,13 +415,38 @@ xyzmatrix.mesh3d<-function(x, ...){
   stopifnot(ncol(value)==3)
   stopifnot(nrow(value)==1 || nrow(value)==length(x))
   if(any(grepl("%g", x, fixed=T)))
-    stop("Sorry I cannot handle input character vectors containing %f")
+    stop("Sorry I cannot handle input character vectors containing %g")
     
   # turn input values into a format string
   fmtstr=gsub("[0-9.\\+eE-]+","%g", x)
   value <- zapsmall(value)
   # remove any negative zeros ...
   value[value==0]=0
+  
+  nfmts=stringr::str_count(fmtstr, stringr::fixed("%g"))
+  if(any(nfmts!=3L)) {
+    # define a default format based on target data
+    default_patt=if(!any(nfmts==3)) "%g, %g, %g" else fmtstr[nfmts==3][1]
+    # check that how many finite replacement values we have been given
+    ngood=3L-rowSums(is.na(value))
+    
+    # if we have 0 formats but >0 good vals in a line, use default pattern
+    fmtstr[nfmts==0 & ngood>0]=default_patt
+    
+    # when we have neither 0 or 3 values to replace
+    funny_lines=nfmts>0 & nfmts!=3
+    if(any(funny_lines)) {
+      # lines where number of (good) replacement values does not match target
+      bad_lines = nfmts[funny_lines]!=ngood[funny_lines]
+      if(any(bad_lines)) {
+        # put the default pattern there
+        fmtstr[funny_lines][bad_lines]=default_patt
+        warning(sum(bad_lines), 
+                " rows of the target did not have a matching number of items in replacement value")
+      }
+    }
+  }
+  
   sprintf(fmtstr, value[,1], value[,2], value[,3])
 }
 

--- a/man/wire3d.Rd
+++ b/man/wire3d.Rd
@@ -17,12 +17,7 @@ wire3d(
 
 \method{wire3d}{hxsurf}(x, Regions = NULL, ...)
 
-\method{wire3d}{mesh3d}(
-  x,
-  override = TRUE,
-  meshColor = c("vertices", "edges", "faces", "legacy"),
-  ...
-)
+\method{wire3d}{mesh3d}(x, ..., front = "lines", back = "lines")
 
 \method{wire3d}{shapelist3d}(x, override = TRUE, ...)
 }
@@ -43,10 +38,11 @@ engine (default: \code{FALSE})
 Default plots all. Seed \code{\link{as.mesh3d}} for details of how the
 argument is handled.}
 
-\item{override}{should the parameters specified here override those stored in the object?}
+\item{front}{Material properties for rendering.}
 
-\item{meshColor}{how should colours be interpreted?  See details 
-  below}
+\item{back}{Material properties for rendering.}
+
+\item{override}{should the parameters specified here override those stored in the object?}
 }
 \description{
 This function directs the wireframe plot based on the plotengine backend selected.

--- a/man/xyzmatrix.Rd
+++ b/man/xyzmatrix.Rd
@@ -87,6 +87,9 @@ Note that \code{xyzmatrix} can extract or set 3D coordinates in a
   \bold{or} has 3 columns named X,Y,Z or x,y,z. As of Nov 2020, if these
   columns are character vectors, they will be correctly converted to numeric
   (with a warning for any NA values).
+}
+\section{Getting and setting from character vectors}{
+
 
   \code{xyzmatrix} can also both get and set 3D coordinates from a character
   vector (including a single data frame column) in which each string encodes
@@ -96,7 +99,26 @@ Note that \code{xyzmatrix} can extract or set 3D coordinates in a
   \code{\link{zapsmall}} in the replacement version to try to avoid cases
   where rounding errors result in long strings of digits to the right of the
   decimal place.
+
+  Replacement into character vectors introduces a number of corner cases when
+  there are not exactly 3 numbers to replace in the target vector. We handle
+  them as follows: \itemize{
+
+  \item 0 values in target, >0 in replacement: use a default pattern
+
+  \item 1-2 values in target, same number of "good" values in replacement:
+  insert those replacement value
+
+  \item 1-2 values in target, different number of values in replacement: use
+  default pattern, give a \code{warning}
+
+  }
+
+  The default pattern will be the first entry in \code{x} with 3 numbers.
+  Should there not be such a value, then the pattern will be \code{"x, y,
+  z"}.
 }
+
 \examples{
 # see all available methods for different classes
 methods('xyzmatrix')

--- a/tests/testthat/test-xform.R
+++ b/tests/testthat/test-xform.R
@@ -213,6 +213,29 @@ test_that("can extract xyz coords of a character vector",{
   coordstr2=paste("(", paste(mx2[,1], mx2[,2], mx2[,3], sep=", "), ")")
   expect_equivalent(xyzmatrix(coordstr) <- mx*-3, xyzmatrix(coordstr2))
   expect_equal(coordstr, coordstr2)
+  
+  xyzmatrix(coordstrna) <- mxna*-3
+  expect_equivalent(xyzmatrix(coordstrna), mxna*-3)
+  
+  # now let's actually change some of the replacement values
+  rep=mxna*-3
+  rep[9,]=rep[1,]
+  xyzmatrix(coordstrna) <- rep
+  expect_equivalent(xyzmatrix(coordstrna), rep)
+  # make sure we infer correct pattern
+  expect_equal(coordstrna[9], coordstrna[1])
+  
+  # replace with more values than were there previously
+  rep[11,]=c(4,5,6)
+  expect_warning(xyzmatrix(coordstrna) <- rep)
+  expect_equivalent(xyzmatrix(coordstrna), rep)
+  # the next time there should no longer be any mismatches
+  expect_silent(xyzmatrix(coordstrna) <- rep)
+  
+  # empty target
+  empty_target=rep("", length(coordstrna))
+  expect_silent(xyzmatrix(empty_target) <- rep)
+  expect_equal(xyzmatrix(empty_target), xyzmatrix(rep))
 })
 
 

--- a/tests/testthat/test-xform.R
+++ b/tests/testthat/test-xform.R
@@ -201,6 +201,10 @@ test_that("can extract xyz coords of a character vector",{
   coordstr=paste("(", paste(mx[,1], mx[,2], mx[,3], sep=", "), ")")
   expect_equal(xyzmatrix(mx), xyzmatrix(coordstr))
   
+  coordstrna=c(coordstr, "c(NA,NA,NA)", "rhubarb", "1e-3 2")
+  mxna=rbind(mx, matrix(NA, ncol=3, nrow=2), cbind(1e-3, 2, NA))
+  expect_equal(xyzmatrix(mxna), xyzmatrix(coordstrna))
+  
   tricky=c(1e-1, 1E+3, -1.01)
   expect_equal(xyzmatrix("1e-1, 1E+3, -1.01"), 
                xyzmatrix(matrix(tricky, ncol=3)))


### PR DESCRIPTION
@alexanderbates this is an important fix that could affect your spreadsheet updates. Specifically `xyzmatrix.character()` was previously silently dropping rows with no/bad values. If these results were then used to calculate e.g. new ids in another column without checking the number of replacement values, they would end up misaligned.