### PR TITLE
Zip command line character limit error fix

### DIFF
--- a/R/neuron-io.R
+++ b/R/neuron-io.R
@@ -895,7 +895,7 @@ write.neurons<-function(nl, dir, format=NULL, subdir=NULL, INDICES=names(nl),
   if(!is.null(zip_file)) {
     owd=setwd(dir)
     on.exit(setwd(owd))
-    zip(zip_file, files=dir(dir, recursive = TRUE))
+    zip(zip_file, files=dir)
     unlink(dir, recursive=TRUE)
     written<-zip_file
   }

--- a/R/neuron-io.R
+++ b/R/neuron-io.R
@@ -895,7 +895,8 @@ write.neurons<-function(nl, dir, format=NULL, subdir=NULL, INDICES=names(nl),
   if(!is.null(zip_file)) {
     owd=setwd(dir)
     on.exit(setwd(owd))
-    zip(zip_file, files=dir)
+    zip(zip_file, 
+        files=if(getRversion()<"3.6.0") dir else dir(dir, recursive = TRUE))
     unlink(dir, recursive=TRUE)
     written<-zip_file
   }


### PR DESCRIPTION
The following change resolves an issue in which a sufficiently long neuronlist would lead to a large number of files being passed into the zip command, thus exceeding the command line character limit when the 'zip' command is called, causing the zip function to error out.