### PR TITLE
Fix handling of null elements in xyzmatrix.list

### DIFF
--- a/R/xyzmatrix.R
+++ b/R/xyzmatrix.R
@@ -103,17 +103,19 @@ xyzmatrix.list<-function(x, empty2na=TRUE, ...) {
     return(xyzmatrix(x$d[,c("X","Y","Z")]))
   
   lens=lengths(x)
-  if(empty2na) {
-    if(!all(lens %in% c(0,3)))
-      stop("xyzmatrix accepts lists where each element has 0 or 3 numbers!")
-    if(any(lens==0))
-      x[lens==0]=list(rep(NA, 3))
-  } else {
+  if(!empty2na) {
     if(any(lens!=3))
       stop("xyzmatrix accepts lists where each element has 3 numbers!")
+  } else {
+    if(!all(lens %in% c(0,3)))
+      stop("xyzmatrix accepts lists where each element has 0 or 3 numbers!")
   }
-  
   mat=matrix(unlist(x, use.names = F), ncol=3, byrow = TRUE)
+  if(any(lens==0)) {
+      mat2=matrix(nrow=length(x), ncol=3)
+      mat2[lens!=0,]=mat
+      mat=mat2
+  }
   xyzmatrix(mat)
 }
 

--- a/tests/testthat/test-xyzmatrix.R
+++ b/tests/testthat/test-xyzmatrix.R
@@ -209,6 +209,15 @@ test_that("can get/replace xyz coords in a list",{
   df$pos=xyzmatrix2list(kcs20)
   xyzmatrix(df$pos)=xyzmatrix(df$pos)+1
   expect_equal(xyzmatrix(df$pos), xyzmatrix(kcs20+1))
+  
+  xyzml[[1]]=rep(NA,3)
+  xyzml[[2]]=list()
+  xyzml[[3]]=list()
+  baseline=rbind(matrix(ncol=3,nrow=3), xyzmatrix(xyzml[4:6]))
+  expect_equal(xyzmatrix(xyzml[1:6]), baseline)
+  expect_error(xyzmatrix(xyzml[1:6], empty2na = F))
+  xyzml[[1]]=rep(NA,2)
+  expect_error(xyzmatrix(xyzml[1:6]))
 })
 
 


### PR DESCRIPTION
* actually test these cases as well

example from fafbseg
```
> fn=flywire_nuclei(c("720575940613259167", "720575940625038394", "720575940635678832", 
+                    "720575940636680282"), rawcoords = T)
Error: Problem with `mutate()` input `..1`.
`..1 = across(ends_with("position"), function(x) xyzmatrix2str(flywire_nm2raw(x)))`.
x Can't convert <list_of<integer>> to <list<integer>>.
```