### PR TITLE
Changed neimode argument to mode

### DIFF
--- a/R/neuron-io.R
+++ b/R/neuron-io.R
@@ -783,7 +783,7 @@ write.neuron.swc<-function(x, file, normalise.ids=NA, metadata=NULL, ...){
   
   if(normalise.ids) {
     g=as.ngraph(x)
-    r=igraph::dfs(g, root=x$StartPoint, neimode = 'all')
+    r=igraph::dfs(g, root=x$StartPoint, mode = 'all')
     new_order=as.integer(r$order)
     df=df[new_order,]
     df$Parent=match(df$Parent, df$PointNo, nomatch = -1L)

--- a/R/neuron.R
+++ b/R/neuron.R
@@ -777,7 +777,7 @@ smooth_segment_spline <- function(xyz, ...) {
 #' ng=as.ngraph(n)
 #' # use a depth first search
 #' distal_points=igraph::graph.dfs(ng, root=n$AxonLHEP, unreachable=FALSE,
-#'   neimode='out')$order
+#'   mode='out')$order
 #' distal_tree=subset(n, distal_points)
 #' plot(distal_tree, add=TRUE, col='red', lwd=2)
 #'

--- a/R/ngraph.R
+++ b/R/ngraph.R
@@ -176,7 +176,7 @@ as.directed.usingroot<-function(g, root, mode=c('out','in')){
   if(!igraph::is.directed(g))
     dg=igraph::as.directed(g, mode='arbitrary')
   else dg=g
-  dfs=igraph::graph.dfs(dg, root, unreachable=FALSE, dist=TRUE, neimode='all')
+  dfs=igraph::graph.dfs(dg, root, unreachable=FALSE, dist=TRUE, mode='all')
   el=igraph::get.edgelist(dg)
   
   connected_vertices=which(is.finite(dfs$order))
@@ -397,7 +397,7 @@ strahler_order<-function(x){
     return(list(points=rep(1L, nrow(x$d)),
                 segments=rep(1L, length(x$SegList))))
   
-  b=graph.bfs(s, root=roots, neimode = 'out', unreachable=F, father=T)
+  b=graph.bfs(s, root=roots, mode = 'out', unreachable=F, father=T)
   
   # find neighbours for each node
   n=neighborhood(s, 1, mode='out')

--- a/R/seglist.R
+++ b/R/seglist.R
@@ -140,7 +140,7 @@ as.seglist.igraph<-function(x, origin=NULL, Verbose=FALSE, ...){
   }
   
   # Now do a depth first search to ensure that ordering is correct
-  dfs=graph.dfs(x, root=origin, father=TRUE, neimode='all')
+  dfs=graph.dfs(x, root=origin, father=TRUE, mode='all')
   # cache orders for speed: dfs$order[i] is slooooow in igraph>=1.0
   orders=as.integer(dfs$order)
   ncount=degree(x)

--- a/man/subset.neuron.Rd
+++ b/man/subset.neuron.Rd
@@ -70,7 +70,7 @@ points(t(xyzmatrix(n)[n$AxonLHEP, 1:2]), pch=19, cex=2.5)
 ng=as.ngraph(n)
 # use a depth first search
 distal_points=igraph::graph.dfs(ng, root=n$AxonLHEP, unreachable=FALSE,
-  neimode='out')$order
+  mode='out')$order
 distal_tree=subset(n, distal_points)
 plot(distal_tree, add=TRUE, col='red', lwd=2)
 

--- a/tests/testthat/test-neuron.R
+++ b/tests/testthat/test-neuron.R
@@ -273,7 +273,7 @@ test_that("we can subset a neuron", {
 
 test_that("we can subset a neuron with a vertex sequence", {
   n = Cell07PNs[[1]]
-  n_graph_dfs = igraph::graph.dfs(as.ngraph(n), root = 48, neimode = "out", unreachable = FALSE)
+  n_graph_dfs = igraph::graph.dfs(as.ngraph(n), root = 48, mode = "out", unreachable = FALSE)
   expect_is(n_subset <- subset(n, n_graph_dfs$order, invert = F), 'neuron')
   expect_is(n_subset <- subset(n, n_graph_dfs$order, invert = T), 'neuron')
 })

--- a/vignettes/neurons-as-graph.Rmd
+++ b/vignettes/neurons-as-graph.Rmd
@@ -281,9 +281,9 @@ n=Cell07PNs[[1]]
 g=as.ngraph(n)
 # find the nodes distal to this point
 # nb you must set unreachable=F if you only want to get downstream nodes
-igraph::dfs(g, neimode='out', unreachable = FALSE, root=n$AxonLHEP)
+igraph::dfs(g, mode='out', unreachable = FALSE, root=n$AxonLHEP)
 # the proximal nodes back to the soma (including any branches)
-igraph::dfs(g, neimode='in', unreachable = FALSE, root=n$AxonLHEP)
+igraph::dfs(g, mode='in', unreachable = FALSE, root=n$AxonLHEP)
 ```
 
 Note that `dfs` (depth first search) provides a good way to visit all the nodes


### PR DESCRIPTION
The use of `neimode` causes.
```
Warning in graph.dfs(x, root = origin, father = TRUE, neimode = "all") :
  Argument `neimode' is deprecated; use `mode' instead
```

Changed to `mode`.

Related to the recent `igraph` update and issue reported here: https://github.com/flyconnectome/malevnc/issues/43.
