### PR TITLE
[WIP] units

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,6 +38,7 @@ Imports:
     checkmate,
     stringr,
     pbapply,
+    units,
     zip
 Suggests:
     spelling,

--- a/R/neuronlist.R
+++ b/R/neuronlist.R
@@ -1132,3 +1132,9 @@ prune_twigs.neuronlist <- function(x, twig_length, OmitFailures=NA, ...) {
   if(missing(twig_length)) stop("Missing twig_length argument")
   nlapply(x, prune_twigs, twig_length=twig_length, OmitFailures=OmitFailures, ...)
 }
+
+# Set unit for a neuronlist
+#' @export
+set_units.neuronlist <- function(nl, unit = NULL, ...) {
+  nlapply(nl, function(x) set_units.neuron(x, unit = unit))
+}

--- a/tests/testthat/test-neuron.R
+++ b/tests/testthat/test-neuron.R
@@ -396,3 +396,11 @@ test_that("rerooting neuronlist", {
   rpns=reroot.neuronlist(pns, point = points)
   expect_equal(rpns[[1]]$StartPoint, 12)
 })
+
+test_that("set_units neuron", {
+  pn<-Cell07PNs[[1]]
+  pnu<-set_units.neuron(pn, 'um')
+  # units setting works correctly
+  expect_equal(class(pnu$d$X), "units")
+  expect_equal(class(pnu$d$W), "units")
+})


### PR DESCRIPTION
I decided to include my first attempts to suport units in nat (#470) for reference.

I used `units` package and implemented assignement of units to XYZW columns of a `d` matrix.

Known problems:

- when using Ops it resets to unitless:
```r
> head(pnu$d,2)
  PointNo Label             X             Y             Z         W Parent
1       1     2 186.8660 [um] 132.7093 [um] 88.20393 [um] 1.01 [um]     -1
2       2     2 187.3355 [um] 131.1558 [um] 90.59680 [um] 1.27 [um]      1
> head((pnu+3)$d, 2)
  PointNo Label        X        Y         Z         W Parent
1       1     2 189.8660 135.7093  91.20393 1.01 [um]     -1
2       2     2 190.3355 134.1558  93.59680 1.27 [um]      1
```

- Problems with operations that have units
```r
> pnu+ set_units(3,'um')
Error in pnu + set_units(3, "um") : 
  non-numeric argument to binary operator
In addition: Warning message:
Incompatible methods ("Ops.neuron", "Ops.units") for "+" 
```

- assigning extra class doesn't really help

```r
> class(pnu) <- c(class(pnu), "units")
> pnu
'neuron' with 180 vertices in 1 tree and additional classes 'units'
> pnu + set_units(3,'um')
```

- custom generic `set_units.neurons` doesn't seem to be recognized

```r
> set_units(pn)
Error in UseMethod("set_units") : 
  no applicable method for 'set_units' applied to an object of class "c('neuron', 'list')"
```
Happy to take some pointers.