### PR TITLE
Fix/matching by col numeric

### DIFF
--- a/R/neuronlist.R
+++ b/R/neuronlist.R
@@ -1150,12 +1150,6 @@ id2char <- function(x) {
     # this is the tricky one
     # unfortunately it is slower than bit64::as.integer64
     return(format(x, scientific=F))
-    # seemed like a good idea but didn't go any faster when benchmarked in situ
-    x1=as.character(x)
-    badvals=grepl('+', x1, fixed=T)
-    if(any(badvals))
-      x1[badvals]=format(x[badvals], scientific=F)
-    return(x1)
   }
   warning("unrecognised id class:", paste(class(x), collapse = ','))
   # we don't want to turn logical values into character 

--- a/R/neuronlist.R
+++ b/R/neuronlist.R
@@ -298,11 +298,13 @@ as.data.frame.neuronlist<-function(x, row.names = names(x), optional = FALSE, ..
   nn=names(x)
   matching_rows=intersect(nn, rownames(value))
   if (length(matching_rows)!=length(nn) && any(nn %in% value[,1])) {
-    matching_rows_fc=intersect(nn, value[,1])
+    # need to turn them into string
+    candids <- id2char(value[,1])
+    matching_rows_fc=intersect(nn, candids)
     if (length(matching_rows)<length(matching_rows_fc)){
       warning("Matching neurons by first column.")
       matching_rows=matching_rows_fc
-      rownames(value) <- value[,1]
+      rownames(value) <- candids
     }
   }
   if(length(matching_rows)){

--- a/R/neuronlist.R
+++ b/R/neuronlist.R
@@ -1140,3 +1140,25 @@ prune_twigs.neuronlist <- function(x, twig_length, OmitFailures=NA, ...) {
   if(missing(twig_length)) stop("Missing twig_length argument")
   nlapply(x, prune_twigs, twig_length=twig_length, OmitFailures=OmitFailures, ...)
 }
+
+# helper function to convert numeric ids to character
+id2char <- function(x) {
+  if(is.character(x)) return(x)
+  if(is.integer(x) || inherits(x, "integer64")) return(as.character(x))
+  # if(is.integer(x)) return(as.character(x))
+  if(is.numeric(x)) {
+    # this is the tricky one
+    # unfortunately it is slower than bit64::as.integer64
+    return(format(x, scientific=F))
+    # seemed like a good idea but didn't go any faster when benchmarked in situ
+    x1=as.character(x)
+    badvals=grepl('+', x1, fixed=T)
+    if(any(badvals))
+      x1[badvals]=format(x[badvals], scientific=F)
+    return(x1)
+  }
+  warning("unrecognised id class:", paste(class(x), collapse = ','))
+  # we don't want to turn logical values into character 
+  if(is.logical(x)) return(x)
+  as.character(x)
+}

--- a/tests/testthat/test-neuronlist.R
+++ b/tests/testthat/test-neuronlist.R
@@ -336,6 +336,11 @@ test_that("prune twigs of a neuronlist", {
   expect_lt(pruned_nl[[1]]$NumSegs,n[[1]]$NumSegs)
   expect_lt(pruned_nl[[2]]$NumSegs,n[[2]]$NumSegs)
   expect_lt(pruned_nl[[3]]$NumSegs,n[[3]]$NumSegs)
-  
-  
+})
+
+
+test_that("id2char works", {
+  expect_equal(id2char(1e5), id2char("100000"))
+  expect_equal(id2char(100000L), "100000")
+  expect_equal(id2char(c(100000L, NA)), c("100000", NA))
 })

--- a/tests/testthat/test-neuronlist.R
+++ b/tests/testthat/test-neuronlist.R
@@ -287,7 +287,8 @@ test_that("as.data.frame.neuronlist behaves", {
   kcs20nodf=kcs20
   data.frame(kcs20nodf)=NULL
   names(kcs20nodf)=df$gene_name
-  kcs20nodf[,]=df
+  expect_warning(kcs20nodf[,] <- df, 'Matching neurons by first column')
+  expect_equal(rownames(kcs20nodf[,]), as.character(df$gene_name))
 })
 
 context("neuronlist: [")

--- a/tests/testthat/test-neuronlist.R
+++ b/tests/testthat/test-neuronlist.R
@@ -282,6 +282,12 @@ test_that("as.data.frame.neuronlist behaves", {
   expect_equal(kcs20nodf[,], kcs20[,])
   expect_equal(rownames(kcs20[,]), rownames(kcs20nodf[,]))
   
+  # numeric id column
+  df$gene_name=1e3+seq_along(kcs20)-1
+  kcs20nodf=kcs20
+  data.frame(kcs20nodf)=NULL
+  names(kcs20nodf)=df$gene_name
+  kcs20nodf[,]=df
 })
 
 context("neuronlist: [")


### PR DESCRIPTION
* Fixes #503
* but we still need to sort out numeric ids like 1e5, since:
```
> as.character(1e5)
[1] "1e+05"
```