### PR TITLE
Switching off patch in codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  status:
+    patch: off
+

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
 coverage:
   status:
-    patch: off
-
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Not sure if patch checks of coverage are necessarily needed in some cases. More important is the overall coverage of the whole package.
And failing reports of them are quite annoying.
I decided to switch them off, but we can alternatively lower the threshold, or something.