### PR TITLE
Change rgl.* calls to *3d

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@ travisbuildchildren.sh
 ^pkgdown$
 ^\.github$
 ^depends.Rds$
+^codecov\.yml$

--- a/R/neuronlist.R
+++ b/R/neuronlist.R
@@ -428,7 +428,7 @@ as.data.frame.neuronlist<-function(x, row.names = names(x), optional = FALSE, ..
 #' open3d()
 #' plot3d(kcs.reduced,col='red', lwd=2)
 #' plot3d(kcs20,col='grey')
-#' rgl.close()
+#' close3d()
 #'
 #' \dontrun{
 #' # example of using plyr's .inform argument for debugging error conditions
@@ -464,7 +464,7 @@ as.data.frame.neuronlist<-function(x, row.names = names(x), optional = FALSE, ..
 #' open3d()
 #' plot3d(kcs20[1:3])
 #' plot3d(xyzflip)
-#' rgl.close()
+#' close3d()
 #' }
 #'
 #' \dontrun{

--- a/R/neuronlist_interactive_3d.R
+++ b/R/neuronlist_interactive_3d.R
@@ -194,8 +194,8 @@ nlscan <- function(neurons, db=NULL,
     if(Wait){
       chc <- readline("Return to continue, b to go back, s to select, d [save to disk], t to stop, c to cancel (without returning a selection): ")
       if(chc=="c" || chc=='t'){
-        sapply(pl, rgl.pop, type='shape')
-        sapply(more_rgl_ids, rgl.pop, type='shape')
+        sapply(pl, pop3d, type='shape')
+        sapply(more_rgl_ids, pop3d, type='shape')
         break
       }
       if(chc=="s") {
@@ -211,8 +211,8 @@ nlscan <- function(neurons, db=NULL,
       Sys.sleep(sleep)
       i <- i+1
     }
-    sapply(pl, rgl.pop, type='shape')
-    sapply(more_rgl_ids, rgl.pop, type='shape')
+    sapply(pl, pop3d, type='shape')
+    sapply(more_rgl_ids, pop3d, type='shape')
   }
   if(is.null(chc) || chc=='c') return(NULL)
   if(!is.null(selected_file)) savetodisk(selected, selected_file)

--- a/man/nlapply.Rd
+++ b/man/nlapply.Rd
@@ -144,7 +144,7 @@ kcs.reduced=nlapply(kcs20,function(x) subset(x,sample(nrow(x$points),50)))
 open3d()
 plot3d(kcs.reduced,col='red', lwd=2)
 plot3d(kcs20,col='grey')
-rgl.close()
+close3d()
 
 \dontrun{
 # example of using plyr's .inform argument for debugging error conditions
@@ -180,7 +180,7 @@ xyzflip=nmapply(function(...) {Sys.sleep(.2);mirror(...)}, kcs20,
 open3d()
 plot3d(kcs20[1:3])
 plot3d(xyzflip)
-rgl.close()
+close3d()
 }
 
 \dontrun{

--- a/tests/testthat/test-hxsurf.R
+++ b/tests/testthat/test-hxsurf.R
@@ -26,7 +26,7 @@ test_that("we can read hxsurf object", {
   plot3d(surf,alpha=0.2)
   nclear3d()
   plot3d(surf,col=rainbow,alpha=0.2)
-  rgl.close()
+  close3d()
   
   #For plotly..
   options(nat.plotengine='plotly')

--- a/tests/testthat/test-neuronlist.R
+++ b/tests/testthat/test-neuronlist.R
@@ -240,7 +240,7 @@ test_that("basic interactive 3d functionality",{
   expect_equal(find.soma(selfun, db=Cell07PNs, rval='neuronlist'), 
                Cell07PNs[sel_soma])
   
-  rgl.close()
+  close3d()
 })
 
 context("neuronlist: set operations")

--- a/tests/testthat/test-pop3d.R
+++ b/tests/testthat/test-pop3d.R
@@ -2,11 +2,11 @@ context("npop3d")
 
 test_that("pop last plotted neurons",{
   nopen3d()
-  original.rgl.ids=rgl.ids()
+  original.rgl.ids=ids3d()
   plot3d(c("EBH11R", "EBH20L"), db=Cell07PNs)
   npop3d()
-  expect_equal(rgl.ids(), original.rgl.ids)
-  rgl.close()
+  expect_equal(ids3d(), original.rgl.ids)
+  close3d()
 })
 
 context("nview3d")


### PR DESCRIPTION
Some upcoming changes to the rgl package will require changes to nat. 
I will be deprecating a number of rgl.* function calls.  You can read 
about the issues here:

   https://dmurdoch.github.io/rgl/articles/deprecation.html

I have made the required changes in the attached patches.  

Duncan Murdoch