### PR TITLE
ci: bump lagging GitHub Actions to current majors

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,7 +32,7 @@ jobs:
       RGL_USE_NULL: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -19,7 +19,7 @@ jobs:
       RGL_USE_NULL: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -40,10 +40,10 @@ jobs:
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: ${{ github.event_name != 'pull_request' && true || false }}
-          file: ./cobertura.xml
+          files: ./cobertura.xml
           plugin: noop
           disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package


### PR DESCRIPTION
## Summary

Three actions in `.github/workflows/` were behind their current major version. This PR brings them up to date.

| Action | Before | After | Notes |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v6` | Node 20 → 24 internals; drop-in |
| `actions/upload-artifact` | `@v4` | `@v7` | Drop-in for the single-artifact failure upload here |
| `codecov/codecov-action` | `@v4` | `@v7` | Also renames deprecated `file:` input to `files:` per v5+ schema |

`r-lib/actions` and `r-hub/actions` intentionally use rolling major tags (`@v2` / `@v1`), so those are correct as-is and not touched.

## Test plan

- [x] No workflow-syntax changes beyond version bumps and the documented `file:` → `files:` rename
- [ ] CI green on this PR (the workflows run on every push/PR, so the bumps validate themselves)
- [ ] Codecov upload still works — visible on the codecov check